### PR TITLE
fix-new-command-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.0.18.0 - 2021-06-17
+
+- Fixes due to change in ESPHome command line format
+
 ## v.0.17.0 - 2021-05-26
 
 - Update schema

--- a/client/src/EsphomeTaskProvider.ts
+++ b/client/src/EsphomeTaskProvider.ts
@@ -4,7 +4,7 @@ let OtaUploadTask = new vscode.Task({
     type: 'esphome',
     task: 'esphome'
 }, vscode.TaskScope.Workspace, 'Upload OTA', 'ESPHome',
-    new vscode.ShellExecution('esphome', ['${relativeFile}', 'run', '--upload-port', 'OTA']));
+    new vscode.ShellExecution('esphome', ['run', '${relativeFile}', '--device', 'OTA']));
 
 class EsphomeTaskProvider implements vscode.TaskProvider {
     static EsphomeType: string = 'esphome';

--- a/server/src/ESPHomeLocalConnection.ts
+++ b/server/src/ESPHomeLocalConnection.ts
@@ -21,7 +21,7 @@ export class ESPHomeLocalConnection extends ESPHomeConnection {
     connect(): void {
         console.log("Using local ESPHome");
 
-        this.process = ChildProcess.exec('esphome dummy vscode',
+        this.process = ChildProcess.exec('esphome vscode dummy',
             { 'encoding': 'utf-8', 'env': { 'PYTHONIOENCODING': 'utf-8' } }
         );
         if (this.process.stdout !== null) {
@@ -35,7 +35,7 @@ export class ESPHomeLocalConnection extends ESPHomeConnection {
                     this.handleMessage(msg);
                 }
                 catch (e) {
-                    console.log(`Error handling reponse: data: ${typeof (data)}: '${data?.toString()}' ${e}`);
+                    console.log(`Error handling response: data: ${typeof (data)}: '${data?.toString()}' ${e}`);
                 }
             });
         }


### PR DESCRIPTION
Fixes command line new format specially the --upload-port now renamed to --device is not compatible.

Requires ESPHome v1.19 from now on

fixes #28