### PR TITLE
Fix SSL support for dashboard validation

### DIFF
--- a/server/src/ESPHomeDashboardConnection.ts
+++ b/server/src/ESPHomeDashboardConnection.ts
@@ -35,7 +35,7 @@ export class ESPHomeDashboardConnection extends ESPHomeConnection {
         }
 
         const httpUri = `${match[2]}://${match[4]}/`;
-        const wsUri = `ws://${match[4]}/vscode`;
+        const wsUri = `ws${match[2] === 'https' ? 's' : ''}://${match[4]}/vscode`;
 
         console.log(`Using ESPHome dashboard at: ${wsUri} server: ${httpUri}`);
         this.ws = new WebSocket(wsUri.toString());


### PR DESCRIPTION
Trying to use an SSL-secured ESPHome instance for dashboard validation fails with a cryptic error because the extension is currently hardcoded to use `ws://`, regardless of configured dashboard URL. Using `wss://` if the user entered an `https://` URL instead fixes it.

Fixes #33