### PR TITLE
V202309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v2023.9.0 - 2023-10-09
 
 - ↔ Sync with ESPHome v2023.9.3 Schema
+- Remove weird identation rules on pasting
+- Fixes some components not listing members like sgp4x
 
 ## v2023.7.0 - 2023-07-23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esphome-vscode",
-  "version": "2023.7.0",
+  "version": "2023.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esphome-vscode",
-      "version": "2023.7.0",
+      "version": "2023.9.0",
       "hasInstallScript": true,
       "devDependencies": {
         "@types/mocha": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esphome-vscode",
   "displayName": "ESPHome",
   "description": "Provide instant validation of ESPHome configuration files",
-  "version": "2023.7.0",
+  "version": "2023.9.0",
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
- ↔ Sync with ESPHome v2023.9.3 Schema
- Remove weird identation rules on pasting
- Fixes some components not listing members like sgp4x
